### PR TITLE
fix bug error ArrayIndexOutOfBoundsException in DatePickerDialog 

### DIFF
--- a/thai-widget/src/main/java/nectec/thai/widget/date/DatePickerDialog.java
+++ b/thai-widget/src/main/java/nectec/thai/widget/date/DatePickerDialog.java
@@ -281,8 +281,8 @@ public class DatePickerDialog extends AlertDialog implements DatePopup, NumberPi
             monthPicker.setOnValueChangedListener(this);
             dayPicker.setOnValueChangedListener(this);
         } else {
-            monthPicker.setMinValue(0);
             monthPicker.setDisplayedValues(THAI_MONTH);
+            monthPicker.setMinValue(0);
             dayPicker.setMinValue(1);
         }
     }


### PR DESCRIPTION
Eng-
fix bug ArrayIndexOutOfBoundsException in DatePickerDialog after set min or maxDate 
Thai-
แก้บัคหลังจากมีการ setMin หรือ maxDate แล้วมีการเกิด ArrayIndexOutOfBoundsException
อ้างอิงจากเอกสาร
https://developer.android.com/reference/android/widget/NumberPicker.html#setDisplayedValues%28java.lang.String%5B%5D%29
